### PR TITLE
Update tags only once per execution

### DIFF
--- a/mam.py
+++ b/mam.py
@@ -163,8 +163,8 @@ def process(m, document):
     tags.append("MAM")
     for t in tags:
         if t not in m.tags:
-        _logger.info("Tag %s not defined in system", t)
-        continue
+            _logger.info("Tag %s not defined in system", t)
+            continue
     data = {"tag_pk": m.tags[t]["id"]}
     result = m.post(m.ep("tags", base=document["url"]), json_data=data)
     sys.path = original_pythonpath

--- a/mam.py
+++ b/mam.py
@@ -88,7 +88,7 @@ def process(m, document):
         except:
             pass
 
-    tags = []
+    tags = set(())
     original_pythonpath = sys.path
     sys.path.append("plugins")
     _, _, files = next(os.walk("plugins"))
@@ -157,18 +157,17 @@ def process(m, document):
                         )
                         pass
 
-            checker_tags = checker.get_tags(complete_content)
-            tags.extend(checker_tags)
-            
-    tags.append("MAM")
+            tags.update(checker.get_tags(complete_content))
+            tags.add("MAM")
+    
     for t in tags:
         if t not in m.tags:
             _logger.info("Tag %s not defined in system", t)
             continue
-    data = {"tag_pk": m.tags[t]["id"]}
-    result = m.post(m.ep("tags", base=document["url"]), json_data=data)
-    sys.path = original_pythonpath
+        data = {"tag_pk": m.tags[t]["id"]}
+        result = m.post(m.ep("tags", base=document["url"]), json_data=data)
 
+    sys.path = original_pythonpath
 
 if __name__ == "__main__":
     main()

--- a/mam.py
+++ b/mam.py
@@ -88,6 +88,7 @@ def process(m, document):
         except:
             pass
 
+    tags = []
     original_pythonpath = sys.path
     sys.path.append("plugins")
     _, _, files = next(os.walk("plugins"))
@@ -156,16 +157,16 @@ def process(m, document):
                         )
                         pass
 
-            tags = checker.get_tags(complete_content)
-            if len(tags) == 0:
-                tags = []
-            tags.append("MAM")
-            for t in tags:
-                if t not in m.tags:
-                    _logger.info("Tag %s not defined in system", t)
-                    continue
-                data = {"tag_pk": m.tags[t]["id"]}
-                result = m.post(m.ep("tags", base=document["url"]), json_data=data)
+            checker_tags = checker.get_tags(complete_content)
+            tags.extend(checker_tags)
+            
+    tags.append("MAM")
+    for t in tags:
+        if t not in m.tags:
+        _logger.info("Tag %s not defined in system", t)
+        continue
+    data = {"tag_pk": m.tags[t]["id"]}
+    result = m.post(m.ep("tags", base=document["url"]), json_data=data)
     sys.path = original_pythonpath
 
 


### PR DESCRIPTION
I want to use the MAM tag to trigger the next step in my mayan metadata workflow. Moreover I want to write a tag to the document no matter if the metadata extraction was successful or not. I use this to put the document in a workflow step to signalise that manual input by the user is required. Thus I created some default plugins in a separate file that match any document of its type and therefore the MAM tag is added to all processed documents. This however leads to duplicated tagging/triggering if there exists another plugin file that matches the document as well.

Therefore I wanted to upload the tags only once per execution and remove duplicates before the upload. If only one matching plugin is found during the execution, the process won't be any different than before.