### PR TITLE
Detect endpoint version (introduced with mayan 4) and handle some v4 API changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,5 @@ services:
       REDIS_URL: redis://results:6379/
       MAYAN_USER: mam-user
       MAYAN_PASSWORD: secretpassword
-      MAYAN_URL: https://yourinstance/api/
+      MAYAN_URL: https://yourinstance/api/v4/
 

--- a/mam.py
+++ b/mam.py
@@ -74,7 +74,7 @@ def process(m, document):
         _logger.error("could not retrieve document")
         return
 
-    if documentep.version is not None:
+    if documentep.version:
         pages = m.all(m.ep("pages", base=document["file_latest"]["url"]))
     else:
         pages = m.all(m.ep("pages", base=document["latest_version"]["url"]))

--- a/mayan.py
+++ b/mayan.py
@@ -126,7 +126,7 @@ class Mayan(object):
             print("WOULD POST", str(endpoint), json.dumps(json_data, indent=2))
             return {}
         result = self.session.post(endpoint, json=json_data)
-        if result.status_code !=  201:
+        if result.status_code != 201:
             _logger.warning(json.dumps(result.json(), indent=2))
         return result.json()
 

--- a/mayan.py
+++ b/mayan.py
@@ -126,7 +126,7 @@ class Mayan(object):
             print("WOULD POST", str(endpoint), json.dumps(json_data, indent=2))
             return {}
         result = self.session.post(endpoint, json=json_data)
-        if result.status_code != 201:
+        if result.status_code not in [200, 201]:
             _logger.warning(json.dumps(result.json(), indent=2))
         return result.json()
 

--- a/mayan.py
+++ b/mayan.py
@@ -11,9 +11,14 @@ _logger = logging.getLogger(__name__)
 class Endpoint(object):
     def __init__(self, endpoint: str, *, params: dict = {}, base: str = None):
         self._paramstring = None
+        self.version = None
         if "://" in endpoint:
             base, endpoint = endpoint.split("api/", 1)
             base += "api/"
+            version = re.search("api/(v\d+)/", endpoint)
+            if version:
+                self.version = version.group(1)
+                base += self.version
             endpoint, self._paramstring = endpoint.split("?", 1)
         if base is None:
             raise Exception('missing base')
@@ -27,6 +32,10 @@ class Endpoint(object):
         if len(params) == 0:
             params = {}
 
+        if not self.version:
+            version = re.search("api/(v\d+)/", base)
+            if version:
+                self.version = version.group(1)
         self.base = base
         self.params = params
         self.endpoint = endpoint

--- a/mayan.py
+++ b/mayan.py
@@ -126,7 +126,7 @@ class Mayan(object):
             print("WOULD POST", str(endpoint), json.dumps(json_data, indent=2))
             return {}
         result = self.session.post(endpoint, json=json_data)
-        if result.status_code != 200:
+        if result.status_code !=  201:
             _logger.warning(json.dumps(result.json(), indent=2))
         return result.json()
 


### PR DESCRIPTION
Signed-off-by: DrRSatzteil <lauterbachthomas@gmail.com>

This PR addresses the API changes that were introduced with Mayan EDMS 4 and upwards. This PR is backwards compatible with Mayan Versions prior to v4.

What this does is:
1. When creating an endpoint in mayan.py it tries to detect the endpoint version and set this as endpoint property "version". API users may then create special cases for certain versions. Note that the MAYAN_URL property must include the api version like this: https://yourinstance/api/v4/ (trailing / is mandatory)
2.  mam.py uses the endpoint.version in two cases where the api response structure has changed between v3 and v4.